### PR TITLE
Add Fortis adapter and Stripe webhook

### DIFF
--- a/lib/fortisAdapter.ts
+++ b/lib/fortisAdapter.ts
@@ -1,0 +1,32 @@
+interface FortisChargeResponse {
+  success: boolean;
+  transactionId?: string;
+  error?: string;
+}
+
+export async function chargeWithFortis(amount: number, token: string): Promise<FortisChargeResponse> {
+  const apiKey = process.env.FORTIS_API_KEY;
+  if (!apiKey) {
+    return { success: false, error: 'Fortis API key not configured' };
+  }
+
+  try {
+    const res = await fetch('https://api.fortispay.com/charge', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({ amount, token })
+    });
+
+    if (!res.ok) {
+      return { success: false, error: await res.text() };
+    }
+
+    const data = await res.json();
+    return { success: true, transactionId: data.id };
+  } catch (err: any) {
+    return { success: false, error: err.message };
+  }
+}

--- a/lib/paymentRouter.ts
+++ b/lib/paymentRouter.ts
@@ -1,0 +1,16 @@
+import { chargeWithStripe } from './stripeAdapter';
+import { chargeWithSquare } from './squareAdapter';
+import { chargeWithFortis } from './fortisAdapter';
+
+export async function processPayment(gateway: string, amount: number, token: string) {
+  switch (gateway) {
+    case 'stripe':
+      return chargeWithStripe(amount, token);
+    case 'square':
+      return chargeWithSquare(amount, token);
+    case 'fortis':
+      return chargeWithFortis(amount, token);
+    default:
+      throw new Error(`Unsupported gateway: ${gateway}`);
+  }
+}

--- a/lib/squareAdapter.ts
+++ b/lib/squareAdapter.ts
@@ -1,0 +1,4 @@
+export async function chargeWithSquare(amount: number, sourceId: string) {
+  // Placeholder for Square charge logic using createPayment
+  return { success: true, transactionId: 'square_txn_placeholder' };
+}

--- a/lib/stripeAdapter.ts
+++ b/lib/stripeAdapter.ts
@@ -1,0 +1,4 @@
+export async function chargeWithStripe(amount: number, paymentMethodId: string) {
+  // Placeholder for Stripe charge logic using payment intents
+  return { success: true, transactionId: 'stripe_txn_placeholder' };
+}

--- a/pages/api/webhooks/stripe.ts
+++ b/pages/api/webhooks/stripe.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+
+export const config = { api: { bodyParser: false } };
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2022-11-15'
+});
+
+async function getRawBody(req: NextApiRequest): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  const sig = req.headers['stripe-signature'] as string;
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET || '';
+
+  try {
+    const body = await getRawBody(req);
+    const event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+
+    switch (event.type) {
+      case 'payment_intent.succeeded':
+        console.log('Payment succeeded:', event.data.object.id);
+        break;
+      case 'payment_intent.payment_failed':
+        console.log('Payment failed:', event.data.object.id);
+        break;
+      default:
+        console.log(`Unhandled event type ${event.type}`);
+    }
+
+    res.json({ received: true });
+  } catch (err: any) {
+    console.error(err);
+    res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- implement Fortis payment adapter
- add Fortis support to the router
- create Stripe webhook handler
- placeholder adapters for Stripe and Square

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845854f91d8832f8c31fecadd72ae2d