### PR TITLE
Add basic frontend dashboard with mock data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test

--- a/__tests__/sum.test.js
+++ b/__tests__/sum.test.js
@@ -1,0 +1,4 @@
+const sum = require('../sum');
+test('adds 1 + 2 to equal 3', () => {
+  expect(sum(1, 2)).toBe(3);
+});

--- a/components/DashboardCard.tsx
+++ b/components/DashboardCard.tsx
@@ -1,0 +1,13 @@
+interface DashboardCardProps {
+  title: string;
+  value: string | number;
+}
+
+export default function DashboardCard({ title, value }: DashboardCardProps) {
+  return (
+    <div className="bg-white rounded shadow p-4">
+      <h2 className="text-sm text-gray-500">{title}</h2>
+      <p className="text-2xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <nav className="bg-blue-600 text-white p-4">
+        <h1 className="text-lg font-bold">Merchant Dashboard</h1>
+      </nav>
+      <main className="p-4">{children}</main>
+    </div>
+  );
+}

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -1,0 +1,28 @@
+import { Transaction } from '../data/mockTransactions';
+
+export default function TransactionTable({ transactions }: { transactions: Transaction[] }) {
+  return (
+    <table className="min-w-full bg-white rounded shadow">
+      <thead>
+        <tr>
+          <th className="p-2 text-left">ID</th>
+          <th className="p-2 text-left">Amount</th>
+          <th className="p-2 text-left">Date</th>
+          <th className="p-2 text-left">Method</th>
+          <th className="p-2 text-left">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {transactions.map(tx => (
+          <tr key={tx.id} className="border-t">
+            <td className="p-2">{tx.id}</td>
+            <td className="p-2">${'{'}tx.amount{'}'}</td>
+            <td className="p-2">{tx.date}</td>
+            <td className="p-2">{tx.method}</td>
+            <td className="p-2">{tx.status}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/data/mockTransactions.ts
+++ b/data/mockTransactions.ts
@@ -1,0 +1,15 @@
+export interface Transaction {
+  id: string;
+  amount: number;
+  date: string;
+  method: string;
+  status: string;
+}
+
+export const mockTransactions: Transaction[] = [
+  { id: 'txn_1', amount: 100, date: '2023-01-01', method: 'card', status: 'succeeded' },
+  { id: 'txn_2', amount: 50, date: '2023-01-05', method: 'crypto', status: 'pending' },
+  { id: 'txn_3', amount: 75, date: '2023-01-10', method: 'card', status: 'failed' },
+  { id: 'txn_4', amount: 125, date: '2023-01-15', method: 'card', status: 'succeeded' },
+  { id: 'txn_5', amount: 200, date: '2023-01-20', method: 'crypto', status: 'succeeded' },
+];

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No tests specified\""
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
 }

--- a/pages/api/transactions.ts
+++ b/pages/api/transactions.ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { mockTransactions } from '../../data/mockTransactions';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ transactions: mockTransactions });
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,24 @@
+import useSWR from 'swr';
+import Layout from '../components/Layout';
+import DashboardCard from '../components/DashboardCard';
+import TransactionTable from '../components/TransactionTable';
+import { Transaction } from '../data/mockTransactions';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function DashboardPage() {
+  const { data } = useSWR<{ transactions: Transaction[] }>('/api/transactions', fetcher);
+  const transactions = data?.transactions || [];
+
+  const totalSales = transactions.reduce((sum, t) => sum + t.amount, 0);
+
+  return (
+    <Layout>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+        <DashboardCard title="Total Sales" value={`$${totalSales}`} />
+        <DashboardCard title="Transactions" value={transactions.length} />
+      </div>
+      <TransactionTable transactions={transactions} />
+    </Layout>
+  );
+}

--- a/setup-tests.sh
+++ b/setup-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Setup script for running tests
+set -e
+
+# Install dependencies
+npm install
+
+# Run tests
+npm test

--- a/sum.js
+++ b/sum.js
@@ -1,0 +1,4 @@
+function sum(a, b) {
+  return a + b;
+}
+module.exports = sum;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create mock transaction data and API route
- add simple Next.js dashboard page with layout
- include TS config

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f8831cbc832f8c7f2276eb9912ae