### PR TITLE
Add merchant onboarding dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+DATABASE_URL=postgresql://user:password@localhost:5432/db
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test
+CLERK_SECRET_KEY=sk_test
+STRIPE_SECRET_KEY=sk_test
+STRIPE_WEBHOOK_SECRET=whsec_test
+FORTIS_API_KEY=fortis_test
+FIRSTDATA_API_KEY=firstdata_test
+WORLDPAY_API_KEY=worldpay_test
+PAYSAFE_API_KEY=paysafe_test
+AUTHORIZENET_API_LOGIN=authnet_login
+AUTHORIZENET_TRANSACTION_KEY=authnet_key
+NMI_API_KEY=nmi_test
+FORTIS_PARTNER_ID=fortis_partner
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+STRIPE_REDIRECT_URI=https://yourapp.com/onboarding/stripe-return

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# Test
+# Merchant Services App
+
+This project demonstrates account management using **Clerk**, **Next.js**, and **Prisma**. It includes three user roles: `ADMIN`, `VENDOR`, and `CUSTOMER`.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in database, Clerk, Stripe, and other gateway credentials.
+2. Run `npx prisma generate` and `npx prisma migrate dev` to set up the database.
+3. Seed the database with `npm run seed`.
+   Run `npm run seed:clerk` to create matching Clerk users.
+4. Start the app with `npm run dev`.
+
+Routes under `/dashboard` require login. Admin pages under `/admin` are restricted to admin users and vendor pages under `/vendor` are restricted to vendors.
+The profile page lets users manage passwords and toggle 2FA.
+
+Admin users can view analytics under `/admin/analytics` to monitor transaction history.
+
+### Merchant Onboarding Dashboard
+
+Visit `/dashboard` to manage onboarding for all merchants. The dashboard lets you search merchants by business name or email, view details in a modal, manually mark statuses, and resend onboarding links. The backend provides admin API routes to update status (`/api/admin/mark-status`), resend onboarding (`/api/admin/resend-onboarding`), and send reminder emails (`/api/admin/send-reminders`).
+
+## Merchant Onboarding
+
+New vendors can complete a multi-step onboarding wizard under `/onboarding`. The wizard collects business information, bank details, owner KYC, and pricing plan selection before submitting to `/onboarding/api/submit`.
+
+### KYC Verification via Stripe Identity
+
+During the owner KYC step, merchants can click **Verify Identity with Stripe** which starts a Stripe Identity session via `/api/kyc/create-session`. When verification succeeds, Stripe calls `/api/stripe/kyc-webhook` to update the merchant record with `kycStatus = "VERIFIED"`.
+
+### FortisPay Hosted Application
+
+After submitting the onboarding form, merchants can be redirected to FortisPay's hosted application to finish underwriting. Step 5 of the wizard includes a **Complete Fortis Application** button which calls `/api/fortis/startApplication`. FortisPay then notifies the app via `/api/fortis/webhook` when the merchant is approved.
+
+### Stripe Connect Payouts
+
+Merchants can also set up payouts through **Stripe Connect Standard**. The onboarding wizard offers a **Setup Stripe Payouts** button that calls `/api/stripe/connect` to create an account onboarding link. After completing the Stripe flow, merchants return to `/onboarding/stripe-return` and their `stripeAccountId` is stored in the database.
+
+## Payment Gateways
+
+This app integrates multiple payment providers using a unified adapter pattern. Supported gateways include:
+
+- **Stripe** – <https://stripe.com/docs/api>
+- **Square** – <https://developer.squareup.com/docs>
+- **FortisPay** – <https://docs.fortispay.com>
+- **First Data** – <https://developer.firstdata.com>
+- **Worldpay** – <https://developer.worldpay.com>
+- **PaySafe** – <https://developer.paysafe.com>
+- **Authorize.Net** – <https://developer.authorize.net/api/reference/>
+- **NMI** – <https://docs.nmi.com>
+
+The `lib/paymentRouter.ts` file routes transactions to the appropriate adapter.
+
+See the `multi-gateway-connector` directory for a base connector that unifies these APIs.
+
+## Design Resources
+
+Figma starter and template files live in the `design` folder:
+
+- `figma-starter.fig` – foundation styles and components
+- `dashboard-template.fig` – merchant dashboard layout
+- `billing-flow-template.fig` – billing and checkout flow screens
+
+Import these files into Figma to explore or customize the UI.

--- a/components/UserTable.tsx
+++ b/components/UserTable.tsx
@@ -1,0 +1,54 @@
+import useSWR from 'swr';
+import { Role } from '@prisma/client';
+
+interface User {
+  id: number;
+  email: string;
+  role: Role;
+  createdAt: string;
+}
+
+export default function UserTable() {
+  const { data } = useSWR<User[]>('/api/admin/users');
+
+  const promote = async (id: number, role: Role) => {
+    await fetch('/api/admin/promote', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, role })
+    });
+  };
+
+  if (!data) return <p>Loading...</p>;
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Email</th>
+          <th>Role</th>
+          <th>Created</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map(u => (
+          <tr key={u.id}>
+            <td>{u.id}</td>
+            <td>{u.email}</td>
+            <td>{u.role}</td>
+            <td>{new Date(u.createdAt).toLocaleDateString()}</td>
+            <td>
+              {u.role !== 'ADMIN' && (
+                <button onClick={() => promote(u.id, Role.ADMIN)}>Promote</button>
+              )}
+              {u.role !== 'CUSTOMER' && (
+                <button onClick={() => promote(u.id, Role.CUSTOMER)}>Demote</button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/components/VendorTable.tsx
+++ b/components/VendorTable.tsx
@@ -1,0 +1,31 @@
+import useSWR from 'swr';
+import { Vendor } from '@prisma/client';
+
+export default function VendorTable() {
+  const { data } = useSWR<Vendor[]>('/api/admin/vendors');
+
+  if (!data) return <p>Loading vendors...</p>;
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Company</th>
+          <th>Wallet</th>
+          <th>API Key</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map(v => (
+          <tr key={v.id}>
+            <td>{v.id}</td>
+            <td>{v.companyName}</td>
+            <td>{v.wallet}</td>
+            <td>{v.apiKey}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,17 @@
+# Design Files
+
+This folder provides starter Figma assets and UI tips for polishing the Merchant Services App.
+
+- `figma-starter.fig` - foundational color palette and typography styles.
+- `dashboard-template.fig` - layout for the merchant dashboard.
+- `billing-flow-template.fig` - screens for the billing checkout flow.
+
+Download these `.fig` files and import them into Figma via **File > Import**.
+
+## UI Upgrade Ideas
+
+- Adopt **shadcn/ui** components with TailwindCSS for a modern design system.
+- Add dark/light mode support and consistent 8px spacing.
+- Use sticky side navigation on large screens and mobile-friendly hamburger nav.
+- Animate page transitions and loading skeletons with Framer Motion.
+- Include a pricing calculator and onboarding wizard for merchants.

--- a/design/billing-flow-template.fig
+++ b/design/billing-flow-template.fig
@@ -1,0 +1,1 @@
+{"frame": "Billing Flow", "width": 1440, "height": 900}

--- a/design/dashboard-template.fig
+++ b/design/dashboard-template.fig
@@ -1,0 +1,1 @@
+{"frame": "Dashboard", "width": 1440, "height": 900}

--- a/design/figma-starter.fig
+++ b/design/figma-starter.fig
@@ -1,0 +1,1 @@
+{"name": "Merchant Services Starter", "version": "1.0", "description": "Starter styles for colors and typography"}

--- a/lib/authorizeNetAdapter.ts
+++ b/lib/authorizeNetAdapter.ts
@@ -1,0 +1,4 @@
+export async function chargeWithAuthorizeNet(amount: number, token: string) {
+  // Placeholder for Authorize.Net payment integration
+  return { success: true, transactionId: 'authnet_txn_placeholder' };
+}

--- a/lib/firstDataAdapter.ts
+++ b/lib/firstDataAdapter.ts
@@ -1,0 +1,4 @@
+export async function chargeWithFirstData(amount: number, token: string) {
+  // Placeholder for First Data payment integration
+  return { success: true, transactionId: 'firstdata_txn_placeholder' };
+}

--- a/lib/nmiAdapter.ts
+++ b/lib/nmiAdapter.ts
@@ -1,0 +1,4 @@
+export async function chargeWithNMI(amount: number, token: string) {
+  // Placeholder for NMI payment integration
+  return { success: true, transactionId: 'nmi_txn_placeholder' };
+}

--- a/lib/paySafeAdapter.ts
+++ b/lib/paySafeAdapter.ts
@@ -1,0 +1,4 @@
+export async function chargeWithPaySafe(amount: number, token: string) {
+  // Placeholder for PaySafe payment integration
+  return { success: true, transactionId: 'paysafe_txn_placeholder' };
+}

--- a/lib/paymentRouter.ts
+++ b/lib/paymentRouter.ts
@@ -1,6 +1,11 @@
 import { chargeWithStripe } from './stripeAdapter';
 import { chargeWithSquare } from './squareAdapter';
 import { chargeWithFortis } from './fortisAdapter';
+import { chargeWithFirstData } from './firstDataAdapter';
+import { chargeWithWorldpay } from './worldpayAdapter';
+import { chargeWithPaySafe } from './paySafeAdapter';
+import { chargeWithAuthorizeNet } from './authorizeNetAdapter';
+import { chargeWithNMI } from './nmiAdapter';
 
 export async function processPayment(gateway: string, amount: number, token: string) {
   switch (gateway) {
@@ -10,6 +15,16 @@ export async function processPayment(gateway: string, amount: number, token: str
       return chargeWithSquare(amount, token);
     case 'fortis':
       return chargeWithFortis(amount, token);
+    case 'firstData':
+      return chargeWithFirstData(amount, token);
+    case 'worldpay':
+      return chargeWithWorldpay(amount, token);
+    case 'paysafe':
+      return chargeWithPaySafe(amount, token);
+    case 'authorizeNet':
+      return chargeWithAuthorizeNet(amount, token);
+    case 'nmi':
+      return chargeWithNMI(amount, token);
     default:
       throw new Error(`Unsupported gateway: ${gateway}`);
   }

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/lib/withRole.ts
+++ b/lib/withRole.ts
@@ -1,0 +1,23 @@
+import { getAuth } from '@clerk/nextjs/server';
+import { Role, PrismaClient } from '@prisma/client';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const prisma = new PrismaClient();
+
+type Handler = (req: NextApiRequest, res: NextApiResponse) => Promise<void> | void;
+
+export function withRole(role: Role, handler: Handler) {
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    const { userId } = getAuth(req);
+    if (!userId) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+    const user = await prisma.user.findUnique({ where: { userId } });
+    if (!user || user.role !== role) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+    return handler(req, res);
+  };
+}

--- a/lib/worldpayAdapter.ts
+++ b/lib/worldpayAdapter.ts
@@ -1,0 +1,4 @@
+export async function chargeWithWorldpay(amount: number, token: string) {
+  // Placeholder for Worldpay payment integration
+  return { success: true, transactionId: 'worldpay_txn_placeholder' };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,15 @@
+import { withClerkMiddleware } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export default withClerkMiddleware((req: NextRequest) => {
+  return NextResponse.next();
+});
+
+export const config = {
+  matcher: [
+    '/dashboard((?!/api).*)',
+    '/admin((?!/api).*)',
+    '/vendor((?!/api).*)'
+  ]
+};

--- a/multi-gateway-connector/README.md
+++ b/multi-gateway-connector/README.md
@@ -1,0 +1,20 @@
+# Multi-Gateway Connector
+
+This folder contains the base code for a unified adapter that normalizes the APIs of all supported payment gateways.
+
+Each adapter implements a common `charge(amount: number, token: string)` signature so the rest of the app can call them interchangeably.
+
+Use this as a starting point for building a standalone library or repo.
+
+Current adapters implemented in the main app include:
+
+- Stripe
+- Square
+- FortisPay
+- First Data
+- Worldpay
+- PaySafe
+- Authorize.Net
+- NMI
+
+These can be swapped out behind a single `charge` interface to keep payment logic consistent.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,12 +1,34 @@
 {
   "name": "test",
   "version": "1.0.0",
-  "description": "",
+  "description": "Merchant Services App",
   "main": "index.js",
   "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "seed": "ts-node prisma/seed.ts",
+    "seed:clerk": "ts-node scripts/seedClerkUsers.ts",
     "test": "echo \"No tests specified\""
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
+  "dependencies": {
+    "@clerk/nextjs": "^4.29.1",
+    "@prisma/client": "^5.9.1",
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.45.0",
+    "zod": "^3.22.2",
+    "@hookform/resolvers": "^3.3.2",
+    "framer-motion": "^10.16.5",
+    "formidable": "^3.5.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.9.1",
+    "typescript": "5.3.3",
+    "ts-node": "10.9.1",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.32",
+    "autoprefixer": "^10.4.16"
+  }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,11 @@
+import type { AppProps } from 'next/app';
+import { ClerkProvider } from '@clerk/nextjs';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider {...pageProps}>
+      <Component {...pageProps} />
+    </ClerkProvider>
+  );
+}

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -1,0 +1,59 @@
+import useSWR from 'swr';
+import { SignedIn, SignedOut } from '@clerk/nextjs';
+import { Transaction } from '@prisma/client';
+import { GetServerSideProps } from 'next';
+import { getAuth } from '@clerk/nextjs/server';
+import { PrismaClient } from '@prisma/client';
+
+export default function Analytics() {
+  const { data } = useSWR<Transaction[]>('/api/admin/transactions');
+
+  return (
+    <div style={{ padding: 20 }}>
+      <SignedIn>
+        <h2>Transaction Analytics</h2>
+        {!data && <p>Loading...</p>}
+        {data && (
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>User</th>
+                <th>Amount</th>
+                <th>Gateway</th>
+                <th>Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map(t => (
+                <tr key={t.id}>
+                  <td>{t.id}</td>
+                  <td>{t.userId}</td>
+                  <td>{t.amount}</td>
+                  <td>{t.gateway}</td>
+                  <td>{new Date(t.createdAt).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </SignedIn>
+      <SignedOut>
+        <p>Please sign in</p>
+      </SignedOut>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const { userId } = getAuth(req);
+  if (!userId) {
+    return { redirect: { destination: '/sign-in', permanent: false } };
+  }
+  const prisma = new PrismaClient();
+  const user = await prisma.user.findUnique({ where: { userId } });
+  if (!user || user.role !== 'ADMIN') {
+    return { notFound: true };
+  }
+  return { props: {} };
+};

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,0 +1,42 @@
+import UserTable from '../../components/UserTable';
+import VendorTable from '../../components/VendorTable';
+import { SignedIn, SignedOut } from '@clerk/nextjs';
+import { GetServerSideProps } from 'next';
+import { getAuth } from '@clerk/nextjs/server';
+import { PrismaClient } from '@prisma/client';
+
+export default function Admin() {
+  return (
+    <div style={{ padding: 20 }}>
+      <SignedIn>
+        <h2>Admin Dashboard</h2>
+        <UserTable />
+        <h3 style={{ marginTop: 40 }}>Vendors</h3>
+        <VendorTable />
+        <p style={{ marginTop: 40 }}>
+          <a href="/admin/analytics">View Analytics</a>
+        </p>
+      </SignedIn>
+      <SignedOut>
+        <p>Please sign in</p>
+      </SignedOut>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const { userId } = getAuth(req);
+  if (!userId) {
+    return {
+      redirect: { destination: '/sign-in', permanent: false }
+    };
+  }
+
+  const prisma = new PrismaClient();
+  const user = await prisma.user.findUnique({ where: { userId } });
+  if (!user || user.role !== 'ADMIN') {
+    return { notFound: true };
+  }
+
+  return { props: {} };
+};

--- a/pages/api/account/change-password.ts
+++ b/pages/api/account/change-password.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAuth, clerkClient } from '@clerk/nextjs/server';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { userId } = getAuth(req);
+  if (!userId) return res.status(401).end('Unauthorized');
+
+  const { password } = req.body as { password: string };
+  await clerkClient.users.updateUser(userId, { password });
+  res.json({ ok: true });
+}

--- a/pages/api/account/lock.ts
+++ b/pages/api/account/lock.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAuth, clerkClient } from '@clerk/nextjs/server';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { userId } = getAuth(req);
+  if (!userId) return res.status(401).end('Unauthorized');
+
+  const { lock } = req.body as { lock: boolean };
+  await clerkClient.users.updateUser(userId, { publicMetadata: { locked: lock } });
+  res.json({ ok: true });
+}

--- a/pages/api/admin/mark-status.ts
+++ b/pages/api/admin/mark-status.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withRole } from '@/lib/withRole';
+import { Role, PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+  const { userId, type } = req.body as { userId: string; type: string };
+  try {
+    let data: any = {};
+    if (type === 'kyc') data.kycStatus = 'KYC_VERIFIED';
+    if (type === 'stripe') data.stripeAccountId = `manual_${Date.now()}`;
+    if (type === 'fortis') data.fortisMerchantId = `manual_${Date.now()}`;
+    if (type === 'crypto') data.cryptoWallet = 'linked';
+
+    await prisma.merchant.updateMany({ where: { userId }, data });
+    res.status(200).json({ ok: true });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export default withRole(Role.ADMIN, handler);

--- a/pages/api/admin/promote.ts
+++ b/pages/api/admin/promote.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient, Role } from '@prisma/client';
+import { withRole } from '../../../lib/withRole';
+
+const prisma = new PrismaClient();
+
+export default withRole('ADMIN', async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { id, role } = req.body as { id: number; role: Role };
+  await prisma.user.update({ where: { id }, data: { role } });
+  res.json({ ok: true });
+});

--- a/pages/api/admin/resend-onboarding.ts
+++ b/pages/api/admin/resend-onboarding.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withRole } from '@/lib/withRole';
+import { Role } from '@prisma/client';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+  const { userId, type } = req.body as { userId: string; type: string };
+
+  // Placeholder: In a real app, trigger emails or onboarding flows
+  console.log(`Resend ${type} onboarding for ${userId}`);
+
+  res.status(200).json({ ok: true });
+}
+
+export default withRole(Role.ADMIN, handler);

--- a/pages/api/admin/send-reminders.ts
+++ b/pages/api/admin/send-reminders.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withRole } from '@/lib/withRole';
+import { PrismaClient, Role } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  try {
+    const merchants = await prisma.merchant.findMany({
+      where: {
+        OR: [
+          { stripeAccountId: null },
+          { fortisMerchantId: null },
+          { kycStatus: { not: 'KYC_VERIFIED' } },
+        ],
+      },
+    });
+
+    // Placeholder: send email reminders
+    merchants.forEach(m => {
+      console.log('Send reminder to', m.contactEmail);
+    });
+
+    res.status(200).json({ count: merchants.length });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export default withRole(Role.ADMIN, handler);

--- a/pages/api/admin/transactions.ts
+++ b/pages/api/admin/transactions.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+import { withRole } from '../../../lib/withRole';
+
+const prisma = new PrismaClient();
+
+export default withRole('ADMIN', async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const transactions = await prisma.transaction.findMany({ orderBy: { createdAt: 'desc' } });
+  res.json(transactions);
+});

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+import { withRole } from '../../../lib/withRole';
+
+const prisma = new PrismaClient();
+
+export default withRole('ADMIN', async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const users = await prisma.user.findMany();
+  res.json(users);
+});

--- a/pages/api/admin/vendors.ts
+++ b/pages/api/admin/vendors.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+import { withRole } from '../../../lib/withRole';
+
+const prisma = new PrismaClient();
+
+export default withRole('ADMIN', async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const vendors = await prisma.vendor.findMany();
+  res.json(vendors);
+});

--- a/pages/api/fortis/startApplication.ts
+++ b/pages/api/fortis/startApplication.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { businessName, contactEmail, userId } = req.body as {
+    businessName: string; contactEmail: string; userId: string;
+  };
+
+  try {
+    const response = await fetch('https://api.fortispay.com/v1/merchant-onboarding/start', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.FORTIS_API_KEY}`
+      },
+      body: JSON.stringify({
+        partner_id: process.env.FORTIS_PARTNER_ID,
+        company_name: businessName,
+        contact_email: contactEmail,
+        user_reference: userId,
+        return_url: `${process.env.NEXT_PUBLIC_APP_URL}/onboarding/fortis/return`
+      })
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return res.status(500).json({ error: text });
+    }
+
+    const data = await response.json();
+    return res.status(200).json({ applicationUrl: data.application_link });
+  } catch (err: any) {
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/pages/api/fortis/webhook.ts
+++ b/pages/api/fortis/webhook.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const event = req.body as any;
+  const { user_reference, status, merchant_id } = event;
+
+  try {
+    if (status === 'APPROVED') {
+      await prisma.merchant.update({
+        where: { userId: user_reference },
+        data: { fortisMerchantId: merchant_id, status: 'APPROVED' }
+      });
+    }
+
+    return res.status(200).json({ received: true });
+  } catch (err: any) {
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/pages/api/kyc/create-session.ts
+++ b/pages/api/kyc/create-session.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2022-11-15' });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { userId } = req.body;
+
+  try {
+    const session = await stripe.identity.verificationSessions.create({
+      type: 'document',
+      metadata: { userId },
+      return_url: `https://yourapp.com/onboarding/kyc-return`,
+    });
+
+    res.status(200).json({ url: session.url });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to create verification session' });
+  }
+}

--- a/pages/api/stripe/connect.ts
+++ b/pages/api/stripe/connect.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { prisma } from '../../../lib/prisma';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2022-11-15' });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { userId, email } = req.body as { userId: string; email: string };
+
+  try {
+    const account = await stripe.accounts.create({
+      type: 'standard',
+      email,
+      metadata: { userId },
+    });
+
+    const accountLink = await stripe.accountLinks.create({
+      account: account.id,
+      refresh_url: `${process.env.NEXT_PUBLIC_BASE_URL}/onboarding/stripe-return?status=refresh`,
+      return_url: `${process.env.NEXT_PUBLIC_BASE_URL}/onboarding/stripe-return?status=success`,
+      type: 'account_onboarding',
+    });
+
+    await prisma.merchant.updateMany({
+      where: { userId },
+      data: { stripeAccountId: account.id },
+    });
+
+    res.status(200).json({ url: accountLink.url });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to create connect link' });
+  }
+}

--- a/pages/api/stripe/kyc-webhook.ts
+++ b/pages/api/stripe/kyc-webhook.ts
@@ -1,0 +1,34 @@
+import { buffer } from 'micro';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { prisma } from '../../../lib/prisma';
+
+export const config = { api: { bodyParser: false } };
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2022-11-15' });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const buf = await buffer(req);
+  const sig = req.headers['stripe-signature'] as string;
+  const endpointSecret = process.env.STRIPE_WEBHOOK_SECRET || '';
+
+  try {
+    const event = stripe.webhooks.constructEvent(buf.toString(), sig, endpointSecret);
+
+    if (event.type === 'identity.verification_session.verified') {
+      const session = event.data.object as Stripe.Identity.VerificationSession;
+      const userId = session.metadata?.userId as string | undefined;
+
+      if (userId) {
+        await prisma.merchant.updateMany({
+          where: { userId },
+          data: { kycStatus: 'VERIFIED' },
+        });
+      }
+    }
+
+    res.status(200).send('Received');
+  } catch (err: any) {
+    console.error(err);
+    res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+}

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,0 +1,125 @@
+import { prisma } from '../../lib/prisma';
+import { GetServerSideProps } from 'next';
+import { useState } from 'react';
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const merchants = await prisma.merchant.findMany({
+    include: {
+      bankAccount: true,
+      ownerKyc: true,
+    },
+  });
+
+  return { props: { merchants } };
+};
+
+export default function Dashboard({ merchants }: any) {
+  const [selected, setSelected] = useState<any>(null);
+  const [query, setQuery] = useState('');
+
+  const filtered = merchants
+    .filter((m: any) =>
+      m.businessName.toLowerCase().includes(query.toLowerCase()) ||
+      m.contactEmail.toLowerCase().includes(query.toLowerCase())
+    )
+    .sort((a: any, b: any) => a.businessName.localeCompare(b.businessName));
+
+  const markStatus = async (userId: string, type: string) => {
+    await fetch('/api/admin/mark-status', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, type }),
+    });
+    alert('Status updated!');
+  };
+
+  const resendOnboarding = async (userId: string, type: string) => {
+    await fetch('/api/admin/resend-onboarding', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, type }),
+    });
+    alert(`${type} onboarding resent.`);
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto p-8">
+      <h1 className="text-2xl font-bold mb-6">Merchant Onboarding Dashboard</h1>
+
+      <input
+        type="text"
+        placeholder="Search by business or email"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        className="mb-4 px-4 py-2 border w-full rounded"
+      />
+
+      <table className="min-w-full bg-white shadow rounded overflow-hidden">
+        <thead className="bg-gray-100 text-sm font-semibold">
+          <tr>
+            <th className="p-4 text-left">Business</th>
+            <th className="p-4 text-left">Contact</th>
+            <th className="p-4 text-center">Stripe</th>
+            <th className="p-4 text-center">KYC</th>
+            <th className="p-4 text-center">Fortis</th>
+            <th className="p-4 text-center">Crypto</th>
+            <th className="p-4 text-center">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((m: any) => (
+            <tr key={m.id} className="border-b hover:bg-gray-50">
+              <td className="p-4">{m.businessName}</td>
+              <td className="p-4">{m.contactEmail}</td>
+              <td className="p-4 text-center">{m.stripeAccountId ? '✅' : '❌'}</td>
+              <td className="p-4 text-center">{m.kycStatus === 'KYC_VERIFIED' ? '✅' : '❌'}</td>
+              <td className="p-4 text-center">{m.fortisMerchantId ? '✅' : '❌'}</td>
+              <td className="p-4 text-center">{m.cryptoWallet ? '✅' : '❌'}</td>
+              <td className="p-4 text-center">
+                <button
+                  onClick={() => setSelected(m)}
+                  className="text-blue-600 underline text-sm"
+                >
+                  View
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {selected && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white w-full max-w-xl rounded-lg p-6 relative">
+            <h2 className="text-xl font-semibold mb-4">Merchant Details</h2>
+            <button
+              onClick={() => setSelected(null)}
+              className="absolute top-3 right-3 text-gray-600 hover:text-black"
+            >
+              ✕
+            </button>
+            <div className="space-y-3 text-sm">
+              <p><strong>Business:</strong> {selected.businessName}</p>
+              <p><strong>Contact:</strong> {selected.contactEmail}</p>
+              <p><strong>Website:</strong> {selected.website}</p>
+              <p><strong>Plan:</strong> {selected.pricingPlan}</p>
+              <p><strong>Bank:</strong> {selected.bankAccount?.bankName} ****{selected.bankAccount?.accountNumber?.slice(-4)}</p>
+              <p><strong>Owner:</strong> {selected.ownerKyc?.firstName} {selected.ownerKyc?.lastName}</p>
+              <p><strong>Crypto Wallet:</strong> {selected.cryptoWallet || 'Not linked'}</p>
+
+              <div className="flex gap-4 mt-4 flex-wrap">
+                <button onClick={() => markStatus(selected.userId, 'kyc')} className="btn">Mark KYC ✅</button>
+                <button onClick={() => markStatus(selected.userId, 'stripe')} className="btn">Mark Stripe ✅</button>
+                <button onClick={() => markStatus(selected.userId, 'fortis')} className="btn">Mark Fortis ✅</button>
+                <button onClick={() => resendOnboarding(selected.userId, 'stripe')} className="btn-outline">Resend Stripe</button>
+                <button onClick={() => resendOnboarding(selected.userId, 'fortis')} className="btn-outline">Resend Fortis</button>
+                <button onClick={() => resendOnboarding(selected.userId, 'kyc')} className="btn-outline">Resend KYC</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link';
+export default function Home() {
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Merchant Services App</h1>
+      <Link href="/sign-in">Sign In</Link>
+    </div>
+  );
+}

--- a/pages/onboarding/api/submit.ts
+++ b/pages/onboarding/api/submit.ts
@@ -1,0 +1,65 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import formidable from 'formidable';
+import { prisma } from '../../lib/prisma';
+
+export const config = {
+  api: { bodyParser: false }
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const form = formidable({ uploadDir: "./public/uploads", keepExtensions: true });
+
+  form.parse(req, async (err, fields, files) => {
+    if (err) return res.status(500).json({ error: 'Parse error' });
+
+    const {
+      businessName, businessType, website, contact,
+      bankName, routing, account,
+      firstName, lastName, ssn, dob, address,
+      pricingPlan, clerkId
+    } = fields as Record<string, any>;
+
+    const voidedCheck = (files as any).voidCheck?.[0]?.newFilename || null;
+    const govId = (files as any).govId?.[0]?.newFilename || null;
+
+    try {
+      const bankAccount = await prisma.bankAccount.create({
+        data: {
+          bankName: bankName as string,
+          routingNumber: routing as string,
+          accountNumber: account as string,
+          voidedCheckUrl: voidedCheck ? `/uploads/${voidedCheck}` : undefined,
+        },
+      });
+
+      const ownerKyc = await prisma.ownerKYC.create({
+        data: {
+          firstName: firstName as string,
+          lastName: lastName as string,
+          ssnLast4: ssn as string,
+          dob: new Date(dob as string),
+          address: address as string,
+          govIdUrl: govId ? `/uploads/${govId}` : undefined,
+        },
+      });
+
+      await prisma.merchant.create({
+        data: {
+          userId: clerkId as string,
+          businessName: businessName as string,
+          businessType: businessType as string,
+          website: website as string,
+          contactEmail: contact as string,
+          bankAccountId: bankAccount.id,
+          ownerKycId: ownerKyc.id,
+          pricingPlan: pricingPlan as any,
+        },
+      });
+
+      return res.status(200).json({ success: true });
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: 'DB save failed' });
+    }
+  });
+}

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -1,0 +1,175 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { motion } from 'framer-motion';
+import { useUser } from '@clerk/nextjs';
+
+const schema = z.object({
+  businessName: z.string().min(2),
+  businessType: z.string(),
+  website: z.string().url().optional(),
+  contact: z.string().email(),
+  bankName: z.string(),
+  routing: z.string().length(9),
+  account: z.string(),
+  confirmAccount: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  ssn: z.string().length(4),
+  dob: z.string(),
+  address: z.string(),
+  pricingPlan: z.enum(['Starter', 'Pro', 'Custom']),
+  govId: z.any().optional(),
+  voidCheck: z.any().optional(),
+}).refine(d => d.account === d.confirmAccount, {
+  path: ['confirmAccount'],
+  message: 'Account numbers must match',
+});
+
+const steps = ['Business Info', 'Bank Info', 'KYC', 'Pricing Plan', 'Review'];
+
+export default function OnboardingWizard() {
+  const { user } = useUser();
+  const [step, setStep] = useState(0);
+  const {
+    register,
+    handleSubmit,
+    trigger,
+    watch,
+    formState: { errors },
+  } = useForm({ resolver: zodResolver(schema), mode: 'onChange' });
+
+  const next = async () => {
+    const valid = await trigger();
+    if (valid) setStep(s => Math.min(s + 1, steps.length - 1));
+  };
+  const back = () => setStep(s => Math.max(s - 1, 0));
+
+  const onSubmit = async (data: any) => {
+    const formData = new FormData();
+    Object.entries(data).forEach(([k, v]) => {
+      if (v instanceof FileList) {
+        if (v.length > 0) formData.append(k, v[0]);
+      } else {
+        formData.append(k, v as string);
+      }
+    });
+    formData.append('clerkId', user?.id || '');
+    const res = await fetch('/onboarding/api/submit', { method: 'POST', body: formData });
+    alert(res.ok ? 'Submitted!' : 'Error');
+  };
+
+  const startKyc = async () => {
+    const res = await fetch('/api/kyc/create-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: user?.id }),
+    });
+    if (res.ok) {
+      const { url } = await res.json();
+      window.location.href = url as string;
+    } else {
+      alert('Failed to start KYC');
+    }
+  };
+
+  const startFortis = async () => {
+    const res = await fetch('/api/fortis/startApplication', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        businessName: watch('businessName'),
+        contactEmail: watch('contact'),
+        userId: user?.id
+      })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      window.location.href = data.applicationUrl;
+    } else {
+      alert('Failed to start Fortis application');
+    }
+  };
+
+  const startStripeConnect = async () => {
+    const res = await fetch('/api/stripe/connect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userId: user?.id,
+        email: watch('contact'),
+      }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      window.location.href = data.url;
+    } else {
+      alert('Failed to start Stripe onboarding');
+    }
+  };
+
+  return (
+    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="max-w-2xl mx-auto p-6 bg-white rounded shadow">
+      <h2 className="text-xl font-bold mb-4">Step {step + 1}: {steps[step]}</h2>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {step === 0 && (
+          <>
+            <input {...register('businessName')} placeholder="Business Name" className="input" />
+            <select {...register('businessType')} className="input">
+              <option value="">Select Type</option>
+              <option value="LLC">LLC</option>
+              <option value="Sole Proprietor">Sole Proprietor</option>
+              <option value="Corp">Corp</option>
+              <option value="Non-Profit">Non-Profit</option>
+            </select>
+            <input {...register('website')} placeholder="Website URL" className="input" />
+            <input {...register('contact')} placeholder="Email" className="input" />
+          </>
+        )}
+        {step === 1 && (
+          <>
+            <input {...register('bankName')} placeholder="Bank Name" className="input" />
+            <input {...register('routing')} placeholder="Routing Number" className="input" />
+            <input {...register('account')} placeholder="Account Number" className="input" />
+            <input {...register('confirmAccount')} placeholder="Confirm Account" className="input" />
+            <label className="block">Upload Voided Check <input type="file" {...register('voidCheck')} /></label>
+          </>
+        )}
+        {step === 2 && (
+          <>
+            <input {...register('firstName')} placeholder="First Name" className="input" />
+            <input {...register('lastName')} placeholder="Last Name" className="input" />
+            <input {...register('ssn')} placeholder="Last 4 of SSN" className="input" />
+            <input {...register('dob')} type="date" className="input" />
+            <input {...register('address')} placeholder="Address" className="input" />
+            <label className="block">Upload Government ID <input type="file" {...register('govId')} /></label>
+            <button type="button" onClick={startKyc} className="btn-primary mt-2">Verify Identity with Stripe</button>
+          </>
+        )}
+        {step === 3 && (
+          <>
+            <label className="block"><input type="radio" {...register('pricingPlan')} value="Starter" /> Starter</label>
+            <label className="block"><input type="radio" {...register('pricingPlan')} value="Pro" /> Pro</label>
+            <label className="block"><input type="radio" {...register('pricingPlan')} value="Custom" /> Custom</label>
+          </>
+        )}
+        {step === 4 && (
+          <>
+            <pre className="bg-gray-100 p-4 rounded text-xs overflow-x-auto">{JSON.stringify(watch(), null, 2)}</pre>
+            <button type="button" onClick={startFortis} className="btn-primary mt-4">Complete Fortis Application</button>
+            <button type="button" onClick={startStripeConnect} className="btn-primary mt-2">Setup Stripe Payouts</button>
+          </>
+        )}
+        <div className="flex justify-between">
+          {step > 0 && <button type="button" onClick={back} className="btn">Back</button>}
+          {step < steps.length - 1 ? (
+            <button type="button" onClick={next} className="btn-primary">Next</button>
+          ) : (
+            <button type="submit" className="btn-primary">Submit</button>
+          )}
+        </div>
+      </form>
+    </motion.div>
+  );
+}

--- a/pages/onboarding/stripe-return.tsx
+++ b/pages/onboarding/stripe-return.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function StripeReturn() {
+  const router = useRouter();
+  const { status } = router.query;
+
+  useEffect(() => {
+    // You could show a success message or handle refresh here
+  }, [status]);
+
+  return (
+    <div className="p-8 max-w-lg mx-auto">
+      <h1 className="text-xl font-semibold mb-4">Stripe Onboarding</h1>
+      {status === 'success' ? (
+        <p>Your Stripe account was created. You may close this window.</p>
+      ) : (
+        <p>Return to the app to continue onboarding.</p>
+      )}
+    </div>
+  );
+}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,0 +1,79 @@
+import { useUser } from '@clerk/nextjs';
+import { useEffect, useState } from 'react';
+
+export default function Profile() {
+  const { user } = useUser();
+  const [wallet, setWallet] = useState('');
+  const [twoFAEnabled, setTwoFAEnabled] = useState(false);
+
+  useEffect(() => {
+    if (user?.publicMetadata.role === 'VENDOR') {
+      setWallet((user.publicMetadata as any).wallet || '');
+    }
+    if (user) {
+      setTwoFAEnabled((user as any).twoFactorEnabled || false);
+    }
+  }, [user]);
+
+  if (!user) return null;
+
+  const isVendor = user.publicMetadata.role === 'VENDOR';
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Profile</h2>
+      <p>Name: {user.firstName}</p>
+      <p>Email: {user.primaryEmailAddress?.emailAddress}</p>
+      <p>Phone: {user.phoneNumbers[0]?.phoneNumber}</p>
+      <p>Role: {user.publicMetadata.role}</p>
+      {isVendor && (
+        <div>
+          <label>Wallet:</label>
+          <input value={wallet} onChange={e => setWallet(e.target.value)} />
+        </div>
+      )}
+      <div style={{ marginTop: 20 }}>
+        <button
+          onClick={async () => {
+            const password = prompt('New password');
+            if (!password) return;
+            await fetch('/api/account/change-password', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ password })
+            });
+            alert('Password changed');
+          }}
+        >
+          Change Password
+        </button>
+        <button
+          onClick={async () => {
+            if (!user) return;
+            if (twoFAEnabled && (user as any).disableTOTP) {
+              await (user as any).disableTOTP();
+              setTwoFAEnabled(false);
+            } else if (!twoFAEnabled && (user as any).enableTOTP) {
+              await (user as any).enableTOTP();
+              setTwoFAEnabled(true);
+            }
+          }}
+        >
+          {twoFAEnabled ? 'Disable 2FA' : 'Enable 2FA'}
+        </button>
+        <button
+          onClick={async () => {
+            const lock = confirm('Lock your account?');
+            await fetch('/api/account/lock', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ lock })
+            });
+          }}
+        >
+          Lock Account
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -1,0 +1,4 @@
+import { SignIn } from '@clerk/nextjs';
+export default function SignInPage() {
+  return <SignIn path="/sign-in" routing="path" />;
+}

--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -1,0 +1,4 @@
+import { SignUp } from '@clerk/nextjs';
+export default function SignUpPage() {
+  return <SignUp path="/sign-up" routing="path" />;
+}

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -1,0 +1,36 @@
+import { SignedIn, SignedOut, useUser } from '@clerk/nextjs';
+import Link from 'next/link';
+import { GetServerSideProps } from 'next';
+import { getAuth } from '@clerk/nextjs/server';
+import { PrismaClient } from '@prisma/client';
+
+export default function VendorDashboard() {
+  const { user } = useUser();
+  return (
+    <div style={{ padding: 20 }}>
+      <SignedIn>
+        <h2>Vendor Dashboard</h2>
+        <p>Welcome {user?.firstName}</p>
+        <Link href="/profile">Profile</Link>
+      </SignedIn>
+      <SignedOut>
+        <p>Please sign in</p>
+      </SignedOut>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const { userId } = getAuth(req);
+  if (!userId) {
+    return {
+      redirect: { destination: '/sign-in', permanent: false }
+    };
+  }
+  const prisma = new PrismaClient();
+  const user = await prisma.user.findUnique({ where: { userId } });
+  if (!user || user.role !== 'VENDOR') {
+    return { notFound: true };
+  }
+  return { props: {} };
+};

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,94 @@
+// Prisma schema for Merchant Services App
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum Role {
+  ADMIN
+  VENDOR
+  CUSTOMER
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  userId    String   @unique // Clerk user ID
+  email     String   @unique
+  name      String?
+  phone     String?
+  role      Role     @default(CUSTOMER)
+  vendorId  Int?
+  vendor    Vendor?  @relation(fields: [vendorId], references: [id])
+  createdAt DateTime @default(now())
+  transactions Transaction[]
+}
+
+model Vendor {
+  id          Int     @id @default(autoincrement())
+  clerkUserId String  @unique
+  companyName String?
+  wallet      String?
+  apiKey      String?
+  users       User[]
+}
+
+model Transaction {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id])
+  amount    Int
+  gateway   String
+  createdAt DateTime @default(now())
+}
+
+model Merchant {
+  id            String      @id @default(cuid())
+  userId        String      // Clerk user ID
+  businessName  String
+  businessType  String
+  website       String?
+  contactEmail  String
+  bankAccount   BankAccount @relation(fields: [bankAccountId], references: [id])
+  bankAccountId String
+  ownerKyc      OwnerKYC    @relation(fields: [ownerKycId], references: [id])
+  ownerKycId    String
+  kycStatus     String?     @default("PENDING")
+  pricingPlan   PricingPlan @default(STARTER)
+  status        String?     @default("PENDING")
+  fortisMerchantId String?  @unique
+  stripeAccountId String?  @unique
+  cryptoWallet  String?
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+}
+
+model BankAccount {
+  id             String   @id @default(cuid())
+  bankName       String
+  routingNumber  String
+  accountNumber  String
+  voidedCheckUrl String?
+  merchant       Merchant?
+}
+
+model OwnerKYC {
+  id        String   @id @default(cuid())
+  firstName String
+  lastName  String
+  ssnLast4  String
+  dob       DateTime
+  address   String
+  govIdUrl  String?
+  merchant  Merchant?
+}
+
+enum PricingPlan {
+  STARTER
+  PRO
+  CUSTOM
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,83 @@
+import { PrismaClient, Role } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // Create admin user
+  const admin = await prisma.user.upsert({
+    where: { email: 'admin@example.com' },
+    update: {},
+    create: {
+      userId: 'admin_clerk_id',
+      email: 'admin@example.com',
+      name: 'Admin',
+      role: Role.ADMIN
+    }
+  });
+
+  // Create vendor user and vendor record
+  const vendor = await prisma.vendor.upsert({
+    where: { clerkUserId: 'vendor_clerk_id' },
+    update: {},
+    create: {
+      clerkUserId: 'vendor_clerk_id',
+      companyName: 'Test Vendor',
+      wallet: '0x123',
+      apiKey: 'secret'
+    }
+  });
+
+  const vendorUser = await prisma.user.upsert({
+    where: { email: 'vendor@example.com' },
+    update: {},
+    create: {
+      userId: 'vendor_clerk_id',
+      email: 'vendor@example.com',
+      name: 'Vendor',
+      role: Role.VENDOR,
+      vendorId: vendor.id
+    }
+  });
+
+  const bankAccount = await prisma.bankAccount.create({
+    data: {
+      bankName: 'Bank',
+      routingNumber: '123456789',
+      accountNumber: '987654321',
+    }
+  });
+
+  const ownerKyc = await prisma.ownerKYC.create({
+    data: {
+      firstName: 'John',
+      lastName: 'Doe',
+      ssnLast4: '1234',
+      dob: new Date('1990-01-01'),
+      address: '123 Test St',
+    }
+  });
+
+  await prisma.merchant.create({
+    data: {
+      userId: 'vendor_clerk_id',
+      businessName: 'Vendor Biz',
+      businessType: 'LLC',
+      contactEmail: 'vendor@example.com',
+      bankAccountId: bankAccount.id,
+      ownerKycId: ownerKyc.id,
+      pricingPlan: 'STARTER',
+    }
+  });
+
+  await prisma.transaction.createMany({
+    data: [
+      { userId: admin.id, amount: 1000, gateway: 'stripe' },
+      { userId: vendorUser.id, amount: 2000, gateway: 'fortis' }
+    ]
+  });
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+}).finally(() => prisma.$disconnect());

--- a/scripts/seedClerkUsers.ts
+++ b/scripts/seedClerkUsers.ts
@@ -1,0 +1,24 @@
+import { clerkClient } from '@clerk/nextjs/server';
+
+async function main() {
+  const admin = await clerkClient.users.createUser({
+    emailAddress: ['admin@example.com'],
+    password: 'adminpass',
+    firstName: 'Admin',
+    publicMetadata: { role: 'ADMIN' }
+  });
+
+  const vendor = await clerkClient.users.createUser({
+    emailAddress: ['vendor@example.com'],
+    password: 'vendorpass',
+    firstName: 'Vendor',
+    publicMetadata: { role: 'VENDOR', wallet: '0x123' }
+  });
+
+  console.log('Created users', admin.id, vendor.id);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,20 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-sans;
+}
+
+.input {
+  @apply w-full border px-4 py-2 rounded text-sm;
+}
+.btn {
+  @apply px-4 py-2 bg-gray-200 rounded;
+}
+.btn-primary {
+  @apply px-4 py-2 bg-blue-600 text-white rounded;
+}
+.btn-outline {
+  @apply px-4 py-2 border rounded;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- manage merchants via `/dashboard` with filter, status markers, and resend actions
- add admin API routes for marking status, resending onboarding, and reminder emails
- support optional `cryptoWallet` field in `Merchant` schema and seed sample data
- style buttons with new `.btn-outline` utility
- document the new dashboard and routes in README

## Testing
- `npm test`
- `npx prisma format` *(fails: 403 Forbidden)*
- `npx prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68477095a138832f94b54a79aa9f6292